### PR TITLE
fix integral generation out of limits bug

### DIFF
--- a/respark/rules/generation_rules/generate_integral.py
+++ b/respark/rules/generation_rules/generate_integral.py
@@ -26,7 +26,7 @@ class BaseIntegralRule(GenerationRule):
         rng = self.rng()
 
         offset = rng.uniform_long_inclusive(
-            min_col=min_value_col,
+            min_col=F.lit(0),
             max_col=max_value_col,
             salt=f"random_{self.spark_subtype}_range",
         )


### PR DESCRIPTION
## Overview of changes

- Fix incorrect range calc causing random_integral rules to generate out of min/max when provided col expressions